### PR TITLE
* Fixed error: id3v2: invalid option -- R

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+## key-tools: Musical key analysis tools
+
+(C) Copyright 2013 Mark Hills <mark@xwax.org>
+
+Includes source code from KeyFinder which is (C) Copyright 2011-2013
+Ibrahim Sha'ath and used under the GPLv3 license.
+
+See the COPYING file for licensing terms.
+
+This software is distributed from the following site:
+
+  - http://www.pogo.org.uk/~mark/key-tools/
+
+The build is controlled via Makefile variables. In general
+you should be able to build using:
+
+```bash
+$ make
+$ make install
+```
+
+To change the target prefix, for example:
+
+```bash
+$ make install PREFIX=/opt/key-tools
+```
+
+The Makefile picks up additional variables from a .config file
+in the source directory. You will prefer to use this if you want
+to control build flags for testing and debugging.
+
+---
+
+### macOS Mojave
+
+* Fixed _id3v2_: invalid option `-R`, replaced with `-l`
+* Small modification in _sed_ command for _mac_
+* Added custom [Homebrew](https://brew.sh) _formula_ `key-tools.rb`
+
+  Install with:
+
+  ```
+  $ brew install --HEAD ./key-tools.rb
+  ```
+
+---
+
+### Examples
+
+_Mark has written a great key scanner:_
+
+```
+key-tag (C) Copyright 2013 Mark Hills <mark@xwax.org>
+
+Usage: key-tag [options] <file>
+Tag an audio file with musical key
+
+  -f   Overwrite an existing key in the file tags
+  -t   Output the traditional key instead of position on circle of fifths
+  -n   Display key only, don't tag
+  -h   Display this help message and exit
+```
+
+The key-tag script in key-tools works on one file at a time.
+
+To batch tag in the current directory do this
+
+```bash
+  $ find ./ -type f -print0 | xargs -0 -n1 key-tag
+```
+
+If you want to scan annother directory replace ./ with the folder you want to scan.
+
+If you have a multicore machine try this, it will run 4 instances in parallel:
+
+```bash
+  $ find ./ -type f -print0 | xargs -0 -n1 -P4 key-tag
+```

--- a/key-tag
+++ b/key-tag
@@ -65,7 +65,7 @@ case "$FILE" in
 	KEY=`metaflac --show-tag=KEY "$FILE" | sed -e 's/KEY=//'`
 	;;
 *.mp3)
-	KEY=`id3v2 -R "$FILE" | sed -n 's/^TKEY.*: \([0-9\.]\+\)/\1/p'`
+	KEY=`id3v2 -l "$FILE" | sed -En 's/^TKEY.*: ([0-9\.]+)/\1/p'`
 	;;
 *.ogg)
 	KEY=`vorbiscomment "$FILE" | sed -n 's/^KEY=//p'`

--- a/key-tools.rb
+++ b/key-tools.rb
@@ -1,0 +1,30 @@
+class KeyTools < Formula
+  desc "Musical key analysis tools"
+  homepage 'http://www.pogo.org.uk/~mark/key-tools/'
+  head "https://www.pogo.org.uk/~mark/key-tools.git", branch: "master"
+  license "GPL-3.0"
+  version '0.1'
+
+  depends_on "fftw"
+
+  patch :DATA
+
+  def install
+    system "make"
+    bin.install "key"
+    bin.install "key-tag"
+  end
+end
+
+__END__
+--- a/key-tag
++++ b/key-tag
+@@ -65,7 +65,7 @@ case "$FILE" in
+ 	KEY=`metaflac --show-tag=KEY "$FILE" | sed -e 's/KEY=//'`
+ 	;;
+ *.mp3)
+-	KEY=`id3v2 -R "$FILE" | sed -n 's/^TKEY.*: \([0-9\.]\+\)/\1/p'`
++	KEY=`id3v2 -l "$FILE" | sed -En 's/^TKEY.*: ([0-9\.]+)/\1/p'`
+ 	;;
+ *.ogg)
+ 	KEY=`vorbiscomment "$FILE" | sed -n 's/^KEY=//p'`


### PR DESCRIPTION
* Added support 'bsd sed' for mac
* Added custom 'Homebrew' formula `key-tools.rb`

  Install with:
    $ brew install --HEAD ./key-tools.rb